### PR TITLE
replace link with depends_on

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
   todo-app:
     build:
       context: ./app
-    links:
+    depends_on:
       - todo-database
     environment:
       NODE_ENV: production


### PR DESCRIPTION
Please replace link with depends_on, as link is an outdated feature and will be removed.
https://docs.docker.com/compose/compose-file/compose-file-v3/#links