### PR TITLE
Fix 'Additinal develop property not allowed' issue

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,13 +19,6 @@ services:
     ports:
       - 3000:3000
       - 35729:35729
-    develop:
-      watch:
-        - path: ./app/package.json
-          action: rebuild
-        - path: ./app
-          target: /usr/src/app
-          action: sync
 
   todo-database:
     image: mongo:6


### PR DESCRIPTION
There is an issue in the docker-compose file. When trying "docker compose up -d" command, an error occurs saying "services.todo-app: Additional property is not allowed".

So, to fix this, removed the develop section from the docker-compose file.

![docker-issue](https://github.com/docker/multi-container-app/assets/97059048/252df50a-dc2d-4640-99d5-6c9827834470)
